### PR TITLE
enable TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/asciimath2tex.js",
   "module": "dist/asciimath2tex.mjs",
   "unpkg": "dist/asciimath2tex.umd.js",
+  "types": "dist/asciimath2tex.d.ts",
   "amdName": "AsciiMathParser",
   "files": [
     "dist"


### PR DESCRIPTION
This pull request adds a "types" entry in packages.json, which instructs microbundle to build a TypeScript definitions file.